### PR TITLE
HP : B Fix ability to set a fill that was set to none through stroke

### DIFF
--- a/client/src/app/services/tools/color-applicator-tool/color-applicator-tool.service.ts
+++ b/client/src/app/services/tools/color-applicator-tool/color-applicator-tool.service.ts
@@ -31,6 +31,7 @@ export class ColorApplicatorToolService extends AbstractToolService {
         this.drawStack = drawStack;
 
         this.drawStack.currentStackTarget.subscribe((stackTarget) => {
+            console.log('what');
             this.currentStackTarget = stackTarget;
             this.isOnTarget = true;
         });
@@ -95,7 +96,7 @@ export class ColorApplicatorToolService extends AbstractToolService {
         }
     }
     // tslint:disable-next-line: no-empty
-    onMouseUp(event: MouseEvent): void {}
+    onMouseUp(event: MouseEvent): void {this.isOnTarget = false;}
     // tslint:disable-next-line: no-empty
     onMouseEnter(event: MouseEvent): void {}
     // tslint:disable-next-line: no-empty


### PR DESCRIPTION
I added an additionnal verification in the color-applicator: it now checks the value of the fill color (if none do nothing else color the fill). Should I add a const variable in the constants.ts for 'none'? Because right now I'm comparing directly with a string...