### PR TITLE
XS : D Add tmp fix for client-server communication

### DIFF
--- a/server/app/app.ts
+++ b/server/app/app.ts
@@ -24,8 +24,8 @@ export class Application {
     private config(): void {
         // Middlewares configuration
         this.app.use(logger('dev'));
-        this.app.use(bodyParser.json());
-        this.app.use(bodyParser.urlencoded({ extended: true }));
+        this.app.use(bodyParser.json({ limit: '1000mb' }));
+        this.app.use(bodyParser.urlencoded({ limit: '1000mb', extended: true }));
         this.app.use(cookieParser());
         this.app.use(cors());
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41704009/69298354-942de300-0bdb-11ea-94e8-3193684d7194.png)

By default, the limit of a 'Message' is 100kb (which is a string of 12800 characters), if the string is too long, the server will complain.

Here is the fix.

